### PR TITLE
Configure gcc to wrap stdint.h

### DIFF
--- a/SOURCES/capos-gcc-10.2.0.patch
+++ b/SOURCES/capos-gcc-10.2.0.patch
@@ -463,7 +463,7 @@ diff -ruN baseline-gcc-10.2.0/gcc/config.gcc gcc-10.2.0/gcc/config.gcc
    ;;
 +*-*-coyotos* | *-*-capros*)
 +  extra_options="${extra_options} capos.opt"
-+  use_gcc_stdint=provide
++  use_gcc_stdint=wrap
 +  ;;
  *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
    extra_options="$extra_options gnu-user.opt"


### PR DESCRIPTION
More platforms like ours appear to use this option.  I have tested it on Coyotos.

My current blockers on CapROS base are that the wrong location is searched for libworkaround, and linux-headers is missing the gcc-10 specific configuration.